### PR TITLE
Modernize Git config

### DIFF
--- a/bin/source-control/cai
+++ b/bin/source-control/cai
@@ -77,25 +77,23 @@ if git diff --cached --quiet --exit-code; then
     exit 1
 fi
 
-if ((${#generator_arguments[@]})); then
-    if ! commit_message="$(gen-commit-msg --staged "${generator_arguments[@]}")"; then
-        echo "cai: failed to generate commit message" >&2
-        exit 1
-    fi
-else
-    if ! commit_message="$(gen-commit-msg --staged)"; then
-        echo "cai: failed to generate commit message" >&2
-        exit 1
-    fi
-fi
-
-if [[ -z "$commit_message" ]]; then
-    echo "cai: empty commit message" >&2
-    exit 1
+retry_with_post_commit_hook=0
+if ! commit_message="$(gen-commit-msg --staged "${generator_arguments[@]}")"; then
+    echo "cai: generation failed; committing with placeholder 1" >&2
+    commit_message=1
+    retry_with_post_commit_hook=1
+elif [[ -z "$commit_message" ]]; then
+    echo "cai: empty message; committing with placeholder 1" >&2
+    commit_message=1
+    retry_with_post_commit_hook=1
 fi
 
 echo "cai: $commit_message" >&2
-CAI_SKIP_POST_COMMIT=1 git commit -m "$commit_message"
+if ((retry_with_post_commit_hook)); then
+    git commit -m "$commit_message"
+else
+    CAI_SKIP_POST_COMMIT=1 git commit -m "$commit_message"
+fi
 
 if ((push_after_commit)); then
     git push

--- a/bin/source-control/cai
+++ b/bin/source-control/cai
@@ -8,7 +8,7 @@ Usage: cai [options]
 Stage changes, generate a commit message with pi, and commit.
 
 Options:
-  --staged                    Use current staged changes; do not run git add .
+  --staged                    Use current staged changes; do not run git add --all
   --push                      Run git push after committing
   --provider NAME             pi provider; defaults to PI_COMMIT_PROVIDER or pi settings
   --model PATTERN             pi model pattern/id; defaults to PI_COMMIT_MODEL or pi settings
@@ -69,7 +69,7 @@ while (($#)); do
 done
 
 if ((stage_changes)); then
-    git add .
+    git add --all
 fi
 
 if git diff --cached --quiet --exit-code; then

--- a/bin/source-control/create-glab-mr
+++ b/bin/source-control/create-glab-mr
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 usage() {
     cat <<'EOF'
@@ -23,11 +24,11 @@ fi
 
 cai || true
 
-branch_name="$(git rev-parse --abbrev-ref HEAD)"
-work_issue_no="$(get-work-issue-no $branch_name)"
+branch_name="$(git branch --show-current)"
+work_issue_no="$(get-work-issue-no "$branch_name")"
 
 title=""
-if [ -n "$1" ]; then
+if [ -n "${1:-}" ]; then
     if [ "$1" = "--use-last-commit-msg" ]; then
         title="$(git log -1 --pretty=%B | head -1)"
     else

--- a/bin/source-control/create-glab-mr
+++ b/bin/source-control/create-glab-mr
@@ -22,10 +22,7 @@ if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
     exit 0
 fi
 
-if ! cai && ! git diff --cached --quiet; then
-    echo "create-glab-mr: cai failed; committing staged changes with a placeholder" >&2
-    git commit -m 1
-fi
+cai || true
 
 branch_name="$(git branch --show-current)"
 work_issue_no="$(get-work-issue-no "$branch_name")"

--- a/bin/source-control/create-glab-mr
+++ b/bin/source-control/create-glab-mr
@@ -22,7 +22,10 @@ if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
     exit 0
 fi
 
-cai || true
+if ! cai && ! git diff --cached --quiet; then
+    echo "create-glab-mr: cai failed; committing staged changes with a placeholder" >&2
+    git commit -m 1
+fi
 
 branch_name="$(git branch --show-current)"
 work_issue_no="$(get-work-issue-no "$branch_name")"

--- a/bin/source-control/gen-last-commit-msg
+++ b/bin/source-control/gen-last-commit-msg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 if [ -n "${CAI_SKIP_POST_COMMIT:-}" ]; then
@@ -7,5 +7,5 @@ fi
 
 last_commit_id=$(git rev-parse HEAD)
 if new_commit_message=$(gen-commit-msg "$last_commit_id") && test -n "$new_commit_message"; then
-    git commit --amend -m "$new_commit_message" --no-verify
+    CAI_SKIP_POST_COMMIT=1 git commit --amend -m "$new_commit_message" --no-verify
 fi

--- a/bin/source-control/gen-mr-title
+++ b/bin/source-control/gen-mr-title
@@ -1,4 +1,4 @@
-#!/usr/bin/env uv run --script
+#!/usr/bin/env -S uv run --python 3.14 --script
 # /// script
 # requires-python = ">=3.14"
 # dependencies = [
@@ -63,7 +63,7 @@ def main():
     try:
         # Get branch name for context
         branch_name = subprocess.run(
-            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            ["git", "branch", "--show-current"],
             capture_output=True,
             text=True,
             check=True,
@@ -90,6 +90,9 @@ def main():
             else:
                 # Final fallback: default branch
                 target_branch = get_default_branch()
+
+        if target_branch == branch_name:
+            target_branch = get_default_branch()
 
         # Find the common ancestor (merge base) between current branch and target branch
         merge_base = subprocess.run(

--- a/bin/source-control/gen-unpushed-commit-msgs
+++ b/bin/source-control/gen-unpushed-commit-msgs
@@ -1,19 +1,138 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
-unpushed_commits=$(git log @{u}.. --pretty=format:"%H" || git log $(git main-branch).. --pretty=format:"%H")
-if [ -z "$unpushed_commits" ]; then
-  echo "No unpushed commits found."
-  exit 0
+usage() {
+    cat <<'EOF'
+Usage: gen-unpushed-commit-msgs [--dry-run] [--yes]
+
+Generate messages for placeholder commits that are not present upstream.
+
+Options:
+  --dry-run  Show proposed rewrites without changing history
+  --yes      Rewrite without prompting
+  -h, --help Show this help
+EOF
+}
+
+if [[ ${1:-} == "--write-message" ]]; then
+    printf '%s\n' "${GEN_UNPUSHED_COMMIT_MESSAGE:?}" > "$2"
+    exit 0
 fi
 
-for commit_id in $unpushed_commits; do
-  new_commit_message=$(gen-commit-msg "$commit_id")
-  echo $new_commit_message
-  if ! test -z "$new_commit_message"; then
-      echo "$commit_id: updated message to \"$new_commit_message\""
-      git reword "$commit_id" "$new_commit_message"
-  fi
+dry_run=0
+assume_yes=0
+
+while (($#)); do
+    case "$1" in
+        --dry-run)
+            dry_run=1
+            shift
+            ;;
+        --yes)
+            assume_yes=1
+            shift
+            ;;
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "gen-unpushed-commit-msgs: unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
 done
 
-echo "AI commit message generation complete for all unpushed commits."
+branch_name="$(git branch --show-current)"
+if [[ -z "$branch_name" ]]; then
+    echo "gen-unpushed-commit-msgs: detached HEAD is not supported" >&2
+    exit 1
+fi
+
+if upstream="$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null)"; then
+    base="$upstream"
+elif git show-ref --verify --quiet "refs/remotes/origin/$branch_name"; then
+    base="origin/$branch_name"
+else
+    main_branch="$(git main-branch)"
+    if git show-ref --verify --quiet "refs/remotes/origin/$main_branch"; then
+        base="origin/$main_branch"
+    else
+        base="$main_branch"
+    fi
+fi
+
+if ! git rev-parse --verify --quiet "$base^{commit}" >/dev/null; then
+    echo "gen-unpushed-commit-msgs: base $base does not exist" >&2
+    exit 1
+fi
+
+range="$base..HEAD"
+if [[ -n "$(git rev-list --merges --max-count=1 "$range")" ]]; then
+    echo "gen-unpushed-commit-msgs: $range contains merges, which git history cannot rewrite" >&2
+    exit 1
+fi
+
+commit_ids=()
+new_messages=()
+while IFS= read -r commit_id; do
+    if ! new_commit_message="$(gen-commit-msg "$commit_id")"; then
+        echo "gen-unpushed-commit-msgs: message generation failed; history was not changed" >&2
+        exit 1
+    fi
+    [[ -n "$new_commit_message" ]] || continue
+
+    current_message="$(git log -1 --format=%B "$commit_id")"
+    [[ "$new_commit_message" != "$current_message" ]] || continue
+
+    commit_ids+=("$commit_id")
+    new_messages+=("$new_commit_message")
+    old_subject="$(git log -1 --format=%s "$commit_id")"
+    new_subject="${new_commit_message%%$'\n'*}"
+    printf '%s: %s -> %s\n' "${commit_id:0:12}" "$old_subject" "$new_subject"
+done < <(git rev-list "$range")
+
+if ((${#commit_ids[@]} == 0)); then
+    echo "No placeholder commit messages to update."
+    exit 0
+fi
+
+if ((dry_run)); then
+    exit 0
+fi
+
+if ((!assume_yes)); then
+    if [[ ! -t 0 ]]; then
+        echo "gen-unpushed-commit-msgs: rerun with --yes to rewrite in a non-interactive shell" >&2
+        exit 2
+    fi
+    read -r -p "Rewrite ${#commit_ids[@]} commit message(s)? [y/N] " reply
+    [[ "$reply" == [yY] ]] || exit 0
+fi
+
+original_head="$(git rev-parse HEAD)"
+backup_ref="refs/rewritten/gen-unpushed-commit-msgs/$original_head"
+git update-ref "$backup_ref" "$original_head"
+rewrite_succeeded=0
+
+cleanup() {
+    if ((rewrite_succeeded)); then
+        git update-ref -d "$backup_ref" || true
+    else
+        echo "gen-unpushed-commit-msgs: original HEAD saved at $backup_ref" >&2
+    fi
+}
+trap cleanup EXIT
+
+printf -v editor_command '%q --write-message' "$0"
+
+# Newest-first order keeps the remaining ancestor IDs valid after each rewrite.
+for index in "${!commit_ids[@]}"; do
+    GEN_UNPUSHED_COMMIT_MESSAGE="${new_messages[$index]}" \
+        GIT_EDITOR="$editor_command" \
+        git history reword "${commit_ids[$index]}" --update-refs=head
+done
+
+rewrite_succeeded=1
+echo "Updated ${#commit_ids[@]} unpushed commit message(s)."

--- a/bin/source-control/gen-work-branch-name
+++ b/bin/source-control/gen-work-branch-name
@@ -1,4 +1,4 @@
-#!/usr/bin/env uv run --script
+#!/usr/bin/env -S uv run --python 3.14 --script
 # /// script
 # requires-python = ">=3.14"
 # dependencies = [

--- a/bin/source-control/git-push-and-open-urls
+++ b/bin/source-control/git-push-and-open-urls
@@ -1,4 +1,6 @@
 #!/usr/bin/env fish
 
 git push 2>&1 | open-url-from-output
+set -l push_status $pipestatus[1]
+exit $push_status
 

--- a/bin/source-control/list-repos
+++ b/bin/source-control/list-repos
@@ -41,7 +41,7 @@ def iter_paths_with_ignores(root_path: Path) -> Iterable[Path]:
 def iter_git_repos(root_path: Path) -> Iterable[Path]:
     for child_path in iter_paths_with_ignores(root_path):
         with suppress(PermissionError):
-            if (child_path / ".git").is_dir():
+            if (child_path / ".git").exists():
                 yield child_path
 
 

--- a/home/.config/git/config
+++ b/home/.config/git/config
@@ -12,11 +12,11 @@
   a = add
   sw = switch
   swc = switch --create
-  main-branch = !git rev-parse --verify --quiet --abbrev-ref origin/HEAD -- | yq 'sub(\"origin/\", \"\")'
-  main = !git sw "$(git main-branch)"
+  main-branch = "!branch=$(git symbolic-ref --short refs/remotes/origin/HEAD) && printf '%s\\n' \"${branch#origin/}\""
+  main = !git switch \"$(git main-branch)\"
   cm = commit -m
   cm1 = commit -m 1
-  ca = !git add . && git commit -m
+  ca = !git add --all && git commit -m
   cai = !cai
   caip = !cai --push
   empty = !git commit -m 'empty' --allow-empty && git push
@@ -24,17 +24,57 @@
   d = diff
   ds = diff --staged
   st = status
-  rm-merged-branches = !git worktree prune --expire now && git branch --merged "$(git main-branch)" --format '%(refname:short) %(upstream:track)' | awk '$2 == \"[gone]\" { print $1 }' | xargs -r git branch -d
-  sync = !git main && git pull --prune && git rm-merged-branches
-	reword = "!f() {\n  GIT_SEQUENCE_EDITOR=\"perl -i -pe 's/^pick/reword/ if $. == 1'\" GIT_EDITOR=\"printf \\\"%s\\n\\\" \\\"$2\\\" >\" git rebase -i \"$1^\";\n}; f"
-  undo = reset HEAD^
+  rm-merged-branches = !git worktree prune --expire now && git branch --merged \"$(git main-branch)\" --format '%(refname:short) %(upstream:track)' | awk '$2 == \"[gone]\" { print $1 }' | xargs -r git branch -d
+  sync = !git main && git pull && git rm-merged-branches
+  fixup = history fixup
+  reword = history reword
+  split = history split
+  undo = reset --mixed HEAD^
 
-[rerere]
-  enabled = true
-  autoupdate = true
+[branch]
+  sort = -committerdate
+
+[column]
+  ui = auto
+
+[core]
+  editor = code --wait
+  pager = delta
+  attributesFile = ~/.config/git/gitattributes
+
+[delta]
+  navigate = true
+
+[diff]
+  tool = vscode
+  colorMoved = default
+
+[difftool "vscode"]
+  cmd = code --wait --diff $LOCAL $REMOTE
 
 [fetch]
   prune = true
+
+[help]
+  autoCorrect = prompt
+
+[hook "last-commit-msg"]
+  command = gen-last-commit-msg
+  event = post-commit
+
+[interactive]
+  diffFilter = delta --color-only
+
+[merge]
+  conflictStyle = zdiff3
+  tool = vscode
+
+[merge "mergiraf"]
+  name = mergiraf
+  driver = mergiraf merge --git %O %A %B -s %S -x %X -y %Y -p %P
+
+[mergetool "vscode"]
+  cmd = code --wait --merge $REMOTE $LOCAL $BASE $MERGED
 
 [pull]
   rebase = true
@@ -44,48 +84,11 @@
 
 [rebase]
   autoStash = true
+  updateRefs = true
 
-[branch]
-  sort = -committerdate
+[remote "origin"]
+  followRemoteHEAD = always
 
-[help]
-  autoCorrect = 10
-
-[core]
-  editor = code --wait
-  pager = delta
-	attributesfile = ~/.config/git/gitattributes
-  hooksPath = ~/.config/git/hooks
-
-[diff]
-  tool = vscode
-  colorMoved = default
-
-[difftool "vscode"]
-  cmd = code --wait --diff $LOCAL $REMOTE
-
-[merge]
-  conflictstyle = diff3
-  tool = vscode
-
-[merge]
-  tool = vscode
-
-[mergetool "vscode"]
-  cmd = code --wait --merge $REMOTE $LOCAL $BASE $MERGED
-
-[merge "mergiraf"]
-	name = mergiraf
-	driver = mergiraf merge --git %O %A %B -s %S -x %X -y %Y -p %P
-
-[interactive]
-  diffFilter = delta --color-only
-
-[delta]
-  navigate = true
-
-[color]
-  ui = true
-
-[column]
-  ui = auto
+[rerere]
+  enabled = true
+  autoUpdate = true

--- a/home/.config/git/config
+++ b/home/.config/git/config
@@ -84,9 +84,11 @@
 
 [push]
   autoSetupRemote = true
+  useForceIfIncludes = true
 
 [rebase]
   autoStash = true
+  missingCommitsCheck = error
   updateRefs = true
 
 [remote "origin"]
@@ -95,3 +97,7 @@
 [rerere]
   enabled = true
   autoUpdate = true
+
+
+[safe]
+  bareRepository = explicit

--- a/home/.config/git/config
+++ b/home/.config/git/config
@@ -44,9 +44,9 @@
 
 [delta]
   navigate = true
-  lineNumbers = true
+  line-numbers = true
   hyperlinks = true
-  hyperlinksFileLinkFormat = vscode://file/{path}:{line}
+  hyperlinks-file-link-format = vscode://file/{path}:{line}
 
 [diff]
   tool = vscode

--- a/home/.config/git/config
+++ b/home/.config/git/config
@@ -98,6 +98,5 @@
   enabled = true
   autoUpdate = true
 
-
 [safe]
   bareRepository = explicit

--- a/home/.config/git/config
+++ b/home/.config/git/config
@@ -44,6 +44,9 @@
 
 [delta]
   navigate = true
+  lineNumbers = true
+  hyperlinks = true
+  hyperlinksFileLinkFormat = vscode://file/{path}:{line}
 
 [diff]
   tool = vscode

--- a/home/.config/git/hooks/post-commit
+++ b/home/.config/git/hooks/post-commit
@@ -1,2 +1,0 @@
-#!/bin/bash
-gen-last-commit-msg


### PR DESCRIPTION
## What changed

- replace the custom interactive-rebase `reword` alias with `git history reword`, and add `fixup` and `split`
- migrate the global `post-commit` script to Git's config-based hook API
- keep `origin/HEAD` current with `remote.origin.followRemoteHEAD` and remove the `yq` dependency from `main-branch`
- enable `rebase.updateRefs`, reject dropped rebase commits, use `zdiff3`, and prompt before autocorrecting commands
- add safer force-push and bare-repository defaults
- improve Delta with line numbers and clickable VS Code links
- make `cai` stage the whole repository and fall back to a placeholder commit whose post-commit hook can retry message generation
- make `gen-unpushed-commit-msgs` preview and confirm rewrites, generate every message before changing history, update only `HEAD`, and preserve the original tip on failure
- preserve push failures, avoid recursive commit rewrites, recognize worktrees, and use valid `uv` launchers in source-control helpers
- fix GitLab MR helpers to use the current branch safely and fall back to the default branch when the upstream is the feature branch
- remove the duplicate `[merge]` section, redundant `--prune`/`color.ui`, and normalize formatting

## Compatibility

Requires Git 2.55 for `git history`, configured hooks, and `followRemoteHEAD`. The Brewfile already installs Homebrew Git. `git history` is experimental and currently refuses histories with merges or rewrites that would conflict.

## Checks

- parsed the complete Git config with `git config --file`
- syntax-checked the changed Bash, Fish, and Python helpers
- smoke-tested the `main-branch` and `main` aliases in a temporary repository
- mock-tested `gen-unpushed-commit-msgs` planning, dry-run, editor integration, failure-before-rewrite, and backup cleanup
- integration-tested successful and fallback `cai` commits with post-commit hook behavior